### PR TITLE
fix - getModel refers to wrong class from Brevo SDK.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -77,7 +77,7 @@ class Client
      */
     public function getModel(string $model, array $data = []): ModelInterface
     {
-        $model = str_contains($model, '\\') ? $model : ('Brevo\\Client\\Api\\' . $model);
+        $model = str_contains($model, '\\') ? $model : ('Brevo\\Client\\Model\\' . $model);
         return new $model($data);
     }
 


### PR DESCRIPTION
Hi @juanparati ,

First of all, thanks for writing this little great package to do the heavy lifting connects to SendInBlue (Brevo). While working on this I figured it out the `getModel` gives 500 error (`Class "Brevo\Client\Api\UpdateContact" not found` as an example).

I checked the code and it seems like `getModel` refers to the wrong place.

Can you please check the Pull Request and let me know if it's good to merge.

Kind regards,